### PR TITLE
Fixed a case where multiple simultaneous connections would be bad.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ class ConanServerpp(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
     exports = "*", "!build", "!.vscode"
-    description = ""
+    description = "A library for a simple networking server"
     requires = ("boost_asio/[>=1.69]@bincrafters/stable",
                 "gsl-lite/[>=0.26]@nonstd-lite/stable")
     options = {"shared": [True, False], "withTests": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -10,8 +10,7 @@ tcp_server::tcp_server(port_number port)
         context_,
         boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
     work_(boost::asio::make_work_guard(context_)),
-    port_(acceptor_.local_endpoint().port()),
-    new_socket_(context_)
+    port_(acceptor_.local_endpoint().port())
 {
 }
 


### PR DESCRIPTION
new_socket was a shared resource amongst all acceptors.  Now each
acceptor has a unique socket for itself.