### PR TITLE
Cleanups to code and conanfile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ class ConanServerpp(ConanFile):
     license = "MIT"
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake"
-    exports = "*", "!build", "!.vscode"
+    exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     description = "A library for a simple networking server"
     requires = ("boost_asio/[>=1.69]@bincrafters/stable",
                 "gsl-lite/[>=0.26]@nonstd-lite/stable")

--- a/include/serverpp/core.hpp
+++ b/include/serverpp/core.hpp
@@ -7,6 +7,7 @@
 
 namespace serverpp {
 
+// A byte in serverpp is represented consistently as an unsigned 8-bit integer.
 using byte = std::uint8_t;
 
 // A stream of bytes in Server++ is exposed as a non-owning span.  It is
@@ -19,5 +20,9 @@ using bytes = gsl::span<byte const>;
 // Where necessary, bytes are stored in this type, which has the small string
 // optimization, meaning that most cases will not cause an allocation.
 using byte_storage = std::basic_string<byte>;
+
+// The port identifier for a server is represented by an unsigned 16-bit 
+// integer.
+using port_identifier = std::uint16_t;
 
 }

--- a/include/serverpp/tcp_server.hpp
+++ b/include/serverpp/tcp_server.hpp
@@ -8,21 +8,19 @@
 
 namespace serverpp {
 
-using port_number = std::uint16_t;
-
 //* =========================================================================
 /// A simple TCP/IP server
 //* =========================================================================
-class SERVERPP_EXPORT tcp_server
+class SERVERPP_EXPORT tcp_server final
 {
 public:
     //* =====================================================================
     /// Constructor
-    /// \param port the port number of the server.  If this is zero, then it
-    ///        is considered a wildcard port, which may bind to any unused
+    /// \param port the port identifier of the server.  If this is zero, then 
+    ///        it is considered a wildcard port, which may bind to any unused
     ///        port.  This number can be retrieved with tcp_server::port.
     //* =====================================================================
-    tcp_server(port_number port);
+    explicit tcp_server(port_identifier port);
 
     //* =====================================================================
     /// Destructor
@@ -30,9 +28,9 @@ public:
     ~tcp_server();
 
     //* =====================================================================
-    /// Returns the port number of the server.
+    /// Returns the port identifier of the server.
     //* =====================================================================
-    port_number port() const;
+    port_identifier port() const;
 
     //* =====================================================================
     /// Shut the server down.
@@ -97,7 +95,7 @@ private:
         boost::asio::io_context::executor_type> work_;
         
     boost::asio::ip::tcp::acceptor acceptor_;
-    port_number port_;
+    port_identifier port_;
 };
 
 }

--- a/include/serverpp/tcp_socket.hpp
+++ b/include/serverpp/tcp_socket.hpp
@@ -9,13 +9,13 @@ namespace serverpp {
 //* =========================================================================
 /// A TCP/IP networking socket connection
 //* =========================================================================
-class tcp_socket
+class tcp_socket final
 {
 public:
     //* =====================================================================
     /// Constructor
     //* =====================================================================
-    tcp_socket(boost::asio::ip::tcp::socket &&socket);
+    explicit tcp_socket(boost::asio::ip::tcp::socket &&socket);
 
     //* =====================================================================
     /// Writes a sequence of bytes to the underlying socket.

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -5,7 +5,7 @@ namespace serverpp {
 // ==========================================================================
 // CONSTRUCTOR
 // ==========================================================================
-tcp_server::tcp_server(port_number port)
+tcp_server::tcp_server(port_identifier port)
   : acceptor_(
         context_,
         boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
@@ -25,7 +25,7 @@ tcp_server::~tcp_server()
 // ==========================================================================
 // PORT
 // ==========================================================================
-port_number tcp_server::port() const
+port_identifier tcp_server::port() const
 {
     return port_;
 }


### PR DESCRIPTION
* Conanfile exports cropped down to what is needed to build the library.
* final and explicit keywords added to tcp_server and tcp_socket.
* port_number renamed to port_identifier, because it's not a number
  (it makes no sense to add or subtract ports from each other).