### PR TITLE
Socket now tracks aliveness better.

### DIFF
--- a/include/serverpp/tcp_socket.hpp
+++ b/include/serverpp/tcp_socket.hpp
@@ -2,6 +2,7 @@
 
 #include "serverpp/core.hpp"
 #include <boost/asio/ip/tcp.hpp>
+#include <iostream>
 
 namespace serverpp {
 
@@ -18,11 +19,7 @@ public:
     explicit tcp_socket(boost::asio::ip::tcp::socket &&socket);
 
     //* =====================================================================
-    /// \brief Returns whether the socket is alive.
-    ///
-    /// Note: it may be that data still remains to be read.  Therefore, it
-    /// is only really worthwhile checking this as a result of receiving
-    /// a zero byte payload from async_read.
+    /// \brief Returns whether the socket is still alive.
     //* =====================================================================
     bool is_alive() const;
 
@@ -55,9 +52,10 @@ public:
         socket_.async_read_some(
             boost::asio::buffer(read_buffer_, read_buffer_.size()),
             [this, read_continuation](
-                boost::system::error_code ec,
+                boost::system::error_code const &ec,
                 std::size_t bytes_transferred)
             {
+                alive_ = !ec;
                 read_continuation(
                     bytes{read_buffer_.data(), bytes_transferred});
             });
@@ -74,6 +72,7 @@ public:
 private:
     boost::asio::ip::tcp::socket socket_;
     byte_storage                 read_buffer_;
+    bool                         alive_;
 };
 
 }

--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -23,7 +23,7 @@ tcp_socket::tcp_socket(boost::asio::ip::tcp::socket &&socket)
 // ==========================================================================
 bool tcp_socket::is_alive() const
 {
-    return socket_.is_open();
+    return alive_;
 }
 
 // ==========================================================================


### PR DESCRIPTION
Previously, the socket checked for openness, but a socket that is terminated
from the remote side is still technically open.  However, async_read_some
yields an error in the case that the remote side disconnected, so liveness
is tracked with that instead.