### PR TITLE
Inject io_context into tcp_server.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import CMake
 
 class ConanServerpp(ConanFile):
     name = "serverpp"
-    version = "0.0.1"
+    version = "0.0.2"
     url = "https://github.com/KazDragon/serverpp"
     author = "KazDragon"
     license = "MIT"

--- a/example/echo/conanfile.txt
+++ b/example/echo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-serverpp/[>=0.0.1]@kazdragon/conan-public
+serverpp/[>=0.0.2]@kazdragon/conan-public
 
 [generators]
 cmake

--- a/src/tcp_server.cpp
+++ b/src/tcp_server.cpp
@@ -3,24 +3,9 @@
 namespace serverpp {
 
 // ==========================================================================
-// CONSTRUCTOR
-// ==========================================================================
-tcp_server::tcp_server(port_identifier port)
-  : acceptor_(
-        context_,
-        boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port)),
-    work_(boost::asio::make_work_guard(context_)),
-    port_(acceptor_.local_endpoint().port())
-{
-}
-
-// ==========================================================================
 // DESTRUCTOR
 // ==========================================================================
-tcp_server::~tcp_server()
-{
-    shutdown();
-}
+tcp_server::~tcp_server() = default;
 
 // ==========================================================================
 // PORT
@@ -35,8 +20,7 @@ port_identifier tcp_server::port() const
 // ==========================================================================
 void tcp_server::shutdown()
 {
-    work_.reset();
-    context_.stop();
+    acceptor_.close();
 }
 
 }


### PR DESCRIPTION
This makes it possible to use the io_context for other work, such
as timers and that sort of thing.