### PR TITLE
Simplify build and packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ target_sources(serverpp
 target_link_libraries(serverpp
     PUBLIC
         CONAN_PKG::gsl-lite
-        CONAN_PKG::boost_asio
+        CONAN_PKG::boost
 )
 
 set_target_properties(serverpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
-    project(SERVERPP VERSION 0.0.3)
+    project(SERVERPP VERSION 0.0.4)
 else()
     project(SERVERPP)
 endif()
@@ -12,16 +12,16 @@ if (POLICY CMP0063)
     cmake_policy(SET CMP0063 OLD) # Do not allow hidden visibility for static libs
 endif()
 
-option(SERVERPP_WITH_TESTS "Build with tests included" False)
 option(SERVERPP_COVERAGE  "Build with code coverage options")
 option(SERVERPP_SANITIZE "Build using sanitizers" "")
 message("Building Server++ with config: ${CMAKE_BUILD_TYPE}")
-message("Building Server++ with tests: ${SERVERPP_WITH_TESTS}")
 message("Building Server++ with code coverage: ${SERVERPP_COVERAGE}")
 message("Building Server++ with sanitizers: ${SERVERPP_SANITIZE}")
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
+if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
+endif()
 
 # The required C++ Standard for Server++ is C++14.
 set(CMAKE_CXX_STANDARD 14)
@@ -70,86 +70,12 @@ set_target_properties(serverpp
 
 target_include_directories(serverpp
     PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include/serverpp-${SERVERPP_VERSION}>
-        "${Boost_INCLUDE_DIRS}"
+        ${PROJECT_SOURCE_DIR}/include
 )
 
 generate_export_header(serverpp
     EXPORT_FILE_NAME "${PROJECT_SOURCE_DIR}/include/serverpp/detail/export.hpp"
 )
-
-configure_file(
-    ${PROJECT_SOURCE_DIR}/include/serverpp/version.hpp.in
-    ${PROJECT_SOURCE_DIR}/include/serverpp/version.hpp
-    @ONLY)
-
-install(
-    TARGETS
-        serverpp
-    EXPORT
-        serverpp-config
-    ARCHIVE DESTINATION
-        lib/serverpp-${SERVERPP_VERSION}
-    LIBRARY DESTINATION
-        lib/serverpp-${SERVERPP_VERSION}
-)
-
-install(
-    DIRECTORY
-        include/
-    DESTINATION
-        include/serverpp-${SERVERPP_VERSION}
-)
-
-export(
-    EXPORT
-        serverpp-config
-    FILE
-        "${CMAKE_CURRENT_BINARY_DIR}/serverpp-config.cmake"
-)
-
-install(
-    EXPORT
-        serverpp-config
-    DESTINATION
-        lib/serverpp-${SERVERPP_VERSION}
-)
-
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/serverpp-config-version.cmake"
-    VERSION
-        "${SERVERPP_VERSION}"
-    COMPATIBILITY AnyNewerVersion
-)
-
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/serverpp-config-version.cmake"
-    DESTINATION
-        lib/serverpp-${SERVERPP_VERSION}
-)
-
-if (SERVERPP_WITH_TESTS)
-    enable_testing()
-
-    set(serverpp_tester_tests
-        test/dummy.cpp
-    )
-
-    add_executable(serverpp_tester
-        ${serverpp_tester_tests}
-    )
-
-    target_link_libraries(serverpp_tester
-        PRIVATE
-            serverpp
-            CONAN_PKG::gtest
-    )
-
-    add_test(serverpp_test serverpp_tester)
-endif()
 
 # Add a rule for generating documentation
 if (DOXYGEN_FOUND)

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import CMake
 
 class ConanServerpp(ConanFile):
     name = "serverpp"
-    version = "0.0.3"
+    version = "0.0.4"
     url = "https://github.com/KazDragon/serverpp"
     author = "KazDragon"
     license = "MIT"
@@ -12,17 +12,12 @@ class ConanServerpp(ConanFile):
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     description = "A library for a simple networking server"
     requires = ("boost/[>=1.69]", "gsl-lite/[>=0.34]")
-    options = {"shared": [True, False], "withTests": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
-    default_options = {"shared": False, "withTests": False, "coverage": False, "sanitize": "off"}
-
-    def requirements(self):
-        if (self.options.withTests):
-            self.requires("gtest/[>=1.8.1]@bincrafters/stable")
+    options = {"shared": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
+    default_options = {"shared": False, "coverage": False, "sanitize": "off"}
 
     def configure_cmake(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
-        cmake.definitions["SERVERPP_WITH_TESTS"] = self.options.withTests
         cmake.definitions["SERVERPP_COVERAGE"] = self.options.coverage
         cmake.definitions["SERVERPP_SANITIZE"] = self.options.sanitize
         cmake.configure()

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,8 +11,7 @@ class ConanServerpp(ConanFile):
     generators = "cmake"
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     description = "A library for a simple networking server"
-    requires = ("boost_asio/[>=1.69]@bincrafters/stable",
-                "gsl-lite/[>=0.34]@nonstd-lite/stable")
+    requires = ("boost/[>=1.69]", "gsl-lite/[>=0.34]")
     options = {"shared": [True, False], "withTests": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
     default_options = {"shared": False, "withTests": False, "coverage": False, "sanitize": "off"}
 

--- a/example/echo/CMakeLists.txt
+++ b/example/echo/CMakeLists.txt
@@ -12,22 +12,19 @@ if (POLICY CMP0063)
     cmake_policy(SET CMP0063 OLD) # Do not allow hidden visibility for static libs
 endif()
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
+if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+    conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
+endif()
 
 # The required C++ Standard for Server++ is C++14.
 set(CMAKE_CXX_STANDARD 14)
 
-set (ECHO_SERVER_PUBLIC_SOURCE_FILES
-    src/echo_server.cpp
-)
+add_executable(echo_server)
 
-set (ECHO_SERVER_PUBLIC_HEADER_FILES
-)
-
-add_executable(echo_server
-    ${ECHO_SERVER_PUBLIC_HEADER_FILES}
-    ${ECHO_SERVER_PUBLIC_SOURCE_FILES}
+target_sources(echo_server
+    PRIVATE
+        src/echo_server.cpp
 )
 
 target_link_libraries(echo_server

--- a/test/dummy.cpp
+++ b/test/dummy.cpp
@@ -1,6 +1,0 @@
-#include <gtest/gtest.h>
-
-TEST(dummy, test)
-{
-    ASSERT_TRUE(true);
-}


### PR DESCRIPTION
Now only requires conan-center (no longer requires lesser-maintained nonstd-lite or bincrafters)

Removed some unused parts of the build system.