### PR TITLE
Fixed gsl-lite to 0.34

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
-    project(SERVERPP VERSION 0.0.4)
+    project(SERVERPP VERSION 0.0.5)
 else()
     project(SERVERPP)
 endif()

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import CMake
 
 class ConanServerpp(ConanFile):
     name = "serverpp"
-    version = "0.0.4"
+    version = "0.0.5"
     url = "https://github.com/KazDragon/serverpp"
     author = "KazDragon"
     license = "MIT"
@@ -11,7 +11,7 @@ class ConanServerpp(ConanFile):
     generators = "cmake"
     exports = "*.hpp", "*.in", "*.cpp", "CMakeLists.txt", "*.md", "LICENSE"
     description = "A library for a simple networking server"
-    requires = ("boost/[>=1.69]", "gsl-lite/[>=0.34]")
+    requires = ("boost/[>=1.69]", "gsl-lite/[=0.34]")
     options = {"shared": [True, False], "coverage": [True, False], "sanitize" : ["off", "address"]}
     default_options = {"shared": False, "coverage": False, "sanitize": "off"}
 

--- a/example/echo/conanfile.txt
+++ b/example/echo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-serverpp/[>=0.0.2]@kazdragon/conan-public
+serverpp/[>=0.0.5]@kazdragon/conan-public
 
 [generators]
 cmake


### PR DESCRIPTION
This solves some problems downstream involving constexpr default
construction.