### PR TITLE
Revert "Skip Appveyor build for commits that don't have a particular tag in their message."

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,15 +1,6 @@
 image:
   - Visual Studio 2019
 
-# Build only on the master branch, for PRs
-branches:
-  only:
-    - master
-
-# Skip any commit that doesn't have [MSVC] in the commit message.
-only_commits:
-  message: /\[MSVC\]/
-
 build:
   parallel: true
   verbosity: detailed


### PR DESCRIPTION
This reverts commit 86270c8e0996f3938c4f2fdf135e40064af76471.

This is because of an unintended side-effect where the master branch is no longer
built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kazdragon/serverpp/21)
<!-- Reviewable:end -->
